### PR TITLE
Load local sailsrc config file

### DIFF
--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -5,14 +5,25 @@
  */
 
 //==============================================================================
+var fs = require('fs');
+var sailsrc ={
+  log: {
+    level: "silent"
+  }
+};
+
+var file_path = __dirname.replace(/node_modules\/sails-test-helper\/lib/ig, '');
+file_path = file_path + '.sailsrc';
+
+var extend = fs.readFileSync(file_path);
+extend = JSON.parse(extend.toString());
+
+for (key in extend) {
+  sailsrc[key] = extend[key];
+}
 
 beforeAll(function(done) {
-  require("sails").lift({
-    //-- turn down the log level so we can view the test results
-    log: {
-      level: "silent"
-    }
-  }, function(err, sails) {
+  require("sails").lift(sailsrc, function(err, sails) {
     done && done(err, sails);
   });
 });


### PR DESCRIPTION
This option was developed for scenarios where the sailsrc file need some special config, in our specific case we are not using waterline and implemented Sequelize instead.

Not loading our sailsrc file caused an error in the sails setup for the test suit.
